### PR TITLE
Platform independent file separator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ function ngHtml2jsify(opts) {
   opts.module = opts.module || null;
   opts.extension = opts.extension || 'html';
 
-  var fileMatching = new RegExp("^.*" + path.sep + "(.*)$");
+  var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
 
   return function (file) {
     if (!isExtension(file, opts.extension)) return through();


### PR DESCRIPTION
Current implementation does not work on Windows. This fix works on Unix/Win
