### PR TITLE
Specify a baseDir for a more descriptive filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ gulp.task('scripts', function() {
     .transform(ngHtml2Js({
       module: 'templates', // <---
       extension: 'ngt' // optionally specify what file types to look for
+      baseDir: "src/js" // optionally specify base directory for filename
     }))
     .bundle()
     .pipe(source('bundle.js'))

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ function ngHtml2jsify(opts) {
   opts = opts|| {};
   opts.module = opts.module || null;
   opts.extension = opts.extension || 'html';
+  opts.baseDir = opts.baseDir || null;
 
   var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
 
@@ -27,13 +28,15 @@ function ngHtml2jsify(opts) {
     if (!isExtension(file, opts.extension)) return through();
 
     var data = '';
+    var appDir = process.cwd();
+
     return through(write, end);
 
     function write (buf) { data += buf }
     function end () {
       var content, src, fileName;
       try {
-        fileName = file.match(fileMatching)[1];
+        fileName = opts.baseDir ? file.replace(path.join(appDir, opts.baseDir), '') : file.match(fileMatching)[1];
         content = fs.readFileSync(file, 'utf-8');
         src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
       } catch (error) {

--- a/test/fixtures/output-basedir.js
+++ b/test/fixtures/output-basedir.js
@@ -1,0 +1,14 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+var template = require('./template.html')
+
+},{"./template.html":2}],2:[function(require,module,exports){
+var ngModule = angular.module('/fixtures/template.html', []);
+ngModule.run(['$templateCache', function($templateCache) {
+  $templateCache.put('/fixtures/template.html',
+    '<h2>This is an html template</h2>\n' +
+    '<p>and it should be transformed into a browserify wrapped angular template module</p>\n' +
+    '');
+}]);
+
+module.exports = ngModule;
+},{}]},{},[1]);

--- a/test/spec.js
+++ b/test/spec.js
@@ -3,10 +3,28 @@ var browserify = require('browserify'),
     ngHtml2Js = require('../lib'),
     source = require('vinyl-source-stream'),
     expect = require('chai').expect,
+    cwd = process.cwd(),
+    path = require('path'),
     exec = require('child_process').exec;
 
 
 describe('ngHtml2Js', function(){
+
+  it('should compile html to a browserify module with parent directory included', function(done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .transform(ngHtml2Js({
+        baseDir: '/test'
+      }))
+      .bundle(function(err, bundle) {
+        if (err) {
+          done(err)
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        };
+      });
+  });
 
   it('should compile html to a browserify wrapped angular module', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');


### PR DESCRIPTION
This allows you to specify a baseDir from you app root that will make the filename include a few dirs up from itself.

Example *package.json*
---
````json
  "browserify": {
    "transform": [
      "browserify-ngannotate",
      ["browserify-ng-html2js", { "module": "gsTemplates", "baseDir": "client/src/js" }]
    ]
  },
````
This will make all the filenames start at `client/src/js`.

Example Output
---
```javascript
ngModule.run(['$templateCache', function ($templateCache) {
  $templateCache.put('/auth/tpl/login.tpl.html',
    '<h3>Enter the admin password for your group</h3>\n' +
    '<p>This is the password selected when the group was created.</p>\n' +
    '<div class="alert alert-error" ng-show="error">\n' +
    '  <strong>Error: </strong> {{error}}\n' +
    '</div>\n' +
...
```
Notice how the filename is now `/auth/tpl/login.tpl.html` instead of just `login.tpl.html`

App directory structure
---
```
client/src/js/auth/tpl/login.tpl.html
```

This helps prevent filename collisions in my app, some of my *.tpl.html files have the same name e.g. `index.tpl.html`