### PR TITLE
Require angular

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function ngHtml2jsify(opts) {
         fileName = opts.baseDir ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
         fileName = opts.prefix + fileName;
         content = fs.readFileSync(file, 'utf-8');
-        src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
+        src = 'var angular = require(\'angular\');\n' + ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
       } catch (error) {
         this.emit('error', error);
       }

--- a/test/fixtures/output-basedir.js
+++ b/test/fixtures/output-basedir.js
@@ -2,6 +2,7 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
+var angular = require('angular');
 var ngModule = angular.module('/fixtures/template.html', []);
 ngModule.run(['$templateCache', function($templateCache) {
   $templateCache.put('/fixtures/template.html',
@@ -11,4 +12,4 @@ ngModule.run(['$templateCache', function($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{}]},{},[1]);
+},{"angular":"angular"}]},{},[1]);

--- a/test/fixtures/output-prefix.js
+++ b/test/fixtures/output-prefix.js
@@ -2,6 +2,7 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
+var angular = require('angular');
 var ngModule = angular.module('/app.templates/template.html', []);
 ngModule.run(['$templateCache', function($templateCache) {
   $templateCache.put('/app.templates/template.html',
@@ -11,4 +12,4 @@ ngModule.run(['$templateCache', function($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{}]},{},[1]);
+},{"angular":"angular"}]},{},[1]);

--- a/test/fixtures/output-simple.js
+++ b/test/fixtures/output-simple.js
@@ -2,6 +2,7 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
+var angular = require('angular');
 var ngModule = angular.module('template.html', []);
 ngModule.run(['$templateCache', function($templateCache) {
   $templateCache.put('template.html',
@@ -11,4 +12,4 @@ ngModule.run(['$templateCache', function($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{}]},{},[1]);
+},{"angular":"angular"}]},{},[1]);

--- a/test/fixtures/output.js
+++ b/test/fixtures/output.js
@@ -2,6 +2,7 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
+var angular = require('angular');
 var ngModule;
 try {
   ngModule = angular.module('templates');
@@ -17,4 +18,4 @@ ngModule.run(['$templateCache', function ($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{}]},{},[1]);
+},{"angular":"angular"}]},{},[1]);

--- a/test/spec.js
+++ b/test/spec.js
@@ -13,6 +13,7 @@ describe('ngHtml2Js', function(){
   it('should compile html to a browserify module with parent directory included', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
     browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
       .transform(ngHtml2Js({
         baseDir: '/test'
       }))
@@ -28,6 +29,7 @@ describe('ngHtml2Js', function(){
 
   it('should put path in unix-like format even for windows-users', function(done) {
     browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
       .transform(ngHtml2Js({
         baseDir: '/test'
       }))
@@ -44,6 +46,7 @@ describe('ngHtml2Js', function(){
   it('should compile html to a browserify wrapped angular module', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
     browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
       .transform(ngHtml2Js({
         module: 'templates'
       }))
@@ -59,7 +62,7 @@ describe('ngHtml2Js', function(){
 
   it('should compile html to a browserify wrapped angular module in CLI', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
-    exec('browserify -t [./lib/index.js --module templates] ./test/fixtures/app.js', function (error, stdout, stderr) {
+    exec('browserify -t [./lib/index.js --module templates] --external angular ./test/fixtures/app.js', function (error, stdout, stderr) {
       expect(output).to.equal(stdout);
       done();
     });
@@ -68,6 +71,7 @@ describe('ngHtml2Js', function(){
   it('should compile html to a browserify wrapped angular module without a module', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output-simple.js', 'utf-8');
     browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
       .transform(ngHtml2Js())
       .bundle(function(err, bundle) {
         if (err) {
@@ -82,6 +86,7 @@ describe('ngHtml2Js', function(){
   it('should add prefix to filename if one is provided', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output-prefix.js', 'utf-8');
     browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
       .transform(ngHtml2Js({
         prefix: '/app.templates/'
       }))


### PR DESCRIPTION
Added to the top of the partial output:
```js
var angular = require('angular');
```
Fixes browserify error `ReferenceError: Can't find variable: angular` 
(encountered when unit testing code that hadn't required/loaded angular globally yet)