### PR TITLE
Make require angular optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ gulp.task('scripts', function() {
       module: 'templates', // optional module name
       extension: 'ngt' // optionally specify what file types to look for
       baseDir: "src/js" // optionally specify base directory for filename
-      prefix: '' // optionally specify a prefix to be added to the filename
+      prefix: '' // optionally specify a prefix to be added to the filename,
+      requireAngular: false // (default: false) optionally include `var angular = require('angular');` 
+                            // Supported in Angular 1.3.14 and above if you bundle angular with browserify
     }))
     .bundle()
     .pipe(source('bundle.js'))

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ function ngHtml2jsify(opts) {
   opts.extension = opts.extension || 'html';
   opts.baseDir = opts.baseDir || null;
   opts.prefix = opts.prefix || '';
+  opts.requireAngular = opts.requireAngular || false;
 
   var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
 
@@ -40,7 +41,10 @@ function ngHtml2jsify(opts) {
         fileName = opts.baseDir ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
         fileName = opts.prefix + fileName;
         content = fs.readFileSync(file, 'utf-8');
-        src = 'var angular = require(\'angular\');\n' + ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
+        src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
+        if (opts.requireAngular) {
+          src = 'var angular = require(\'angular\');\n' + src;
+        }
       } catch (error) {
         this.emit('error', error);
       }

--- a/test/fixtures/output-basedir.js
+++ b/test/fixtures/output-basedir.js
@@ -2,7 +2,6 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
-var angular = require('angular');
 var ngModule = angular.module('/fixtures/template.html', []);
 ngModule.run(['$templateCache', function($templateCache) {
   $templateCache.put('/fixtures/template.html',
@@ -12,4 +11,4 @@ ngModule.run(['$templateCache', function($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{"angular":"angular"}]},{},[1]);
+},{}]},{},[1]);

--- a/test/fixtures/output-prefix.js
+++ b/test/fixtures/output-prefix.js
@@ -2,7 +2,6 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
-var angular = require('angular');
 var ngModule = angular.module('/app.templates/template.html', []);
 ngModule.run(['$templateCache', function($templateCache) {
   $templateCache.put('/app.templates/template.html',
@@ -12,4 +11,4 @@ ngModule.run(['$templateCache', function($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{"angular":"angular"}]},{},[1]);
+},{}]},{},[1]);

--- a/test/fixtures/output-require-angular.js
+++ b/test/fixtures/output-require-angular.js
@@ -2,14 +2,9 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
-var ngModule;
-try {
-  ngModule = angular.module('templates');
-} catch (e) {
-  ngModule = angular.module('templates', []);
-}
-
-ngModule.run(['$templateCache', function ($templateCache) {
+var angular = require('angular');
+var ngModule = angular.module('template.html', []);
+ngModule.run(['$templateCache', function($templateCache) {
   $templateCache.put('template.html',
     '<h2>This is an html template</h2>\n' +
     '<p>and it should be transformed into a browserify wrapped angular template module</p>\n' +
@@ -17,4 +12,4 @@ ngModule.run(['$templateCache', function ($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{}]},{},[1]);
+},{"angular":"angular"}]},{},[1]);

--- a/test/fixtures/output-simple.js
+++ b/test/fixtures/output-simple.js
@@ -2,7 +2,6 @@
 var template = require('./template.html')
 
 },{"./template.html":2}],2:[function(require,module,exports){
-var angular = require('angular');
 var ngModule = angular.module('template.html', []);
 ngModule.run(['$templateCache', function($templateCache) {
   $templateCache.put('template.html',
@@ -12,4 +11,4 @@ ngModule.run(['$templateCache', function($templateCache) {
 }]);
 
 module.exports = ngModule;
-},{"angular":"angular"}]},{},[1]);
+},{}]},{},[1]);

--- a/test/spec.js
+++ b/test/spec.js
@@ -99,4 +99,21 @@ describe('ngHtml2Js', function(){
         };
       });
   });
-})
+
+  it('should include a require angular statement inside module', function(done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-require-angular.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+        .external('angular')
+        .transform(ngHtml2Js({
+          requireAngular: true
+        }))
+        .bundle(function(err, bundle) {
+          if (err) {
+            done(err)
+          } else {
+            expect(output).to.equal(bundle.toString());
+            done();
+          };
+        });
+  });
+});


### PR DESCRIPTION
Addresses #18 and #19 by making the [recent change](https://github.com/javoire/browserify-ng-html2js/commit/6777bb269d5d085904a8d633a8924543147fee94)  `var angular = require('angular');` optional. 

```js
ngHtml2Js({      
  requireAngular: false // (default: false) optionally include `var angular = require('angular');` 
                        // Supported in Angular 1.3.14 and above if you bundle angular with browserify
})
```
