### PR TITLE
Remove the BOM from the beginning of the data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ function ngHtml2jsify(opts) {
         fileName = opts.baseDir ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
         fileName = opts.prefix + fileName;
         content = fs.readFileSync(file, 'utf-8');
+        content = content.replace(/^\ufeff/g, '');
         src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
         if (opts.requireAngular) {
           src = 'var angular = require(\'angular\');\n' + src;

--- a/test/fixtures/bom-template.html
+++ b/test/fixtures/bom-template.html
@@ -1,0 +1,1 @@
+﻿<div>this file has a BOM</div>

--- a/test/spec.js
+++ b/test/spec.js
@@ -10,7 +10,7 @@ var browserify = require('browserify'),
 
 describe('ngHtml2Js', function(){
 
-  /*it('should compile html to a browserify module with parent directory included', function(done) {
+  it('should compile html to a browserify module with parent directory included', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
     browserify(__dirname + '/fixtures/app.js')
       .external('angular')
@@ -115,7 +115,7 @@ describe('ngHtml2Js', function(){
             done();
           };
         });
-  }); */
+  });
 
   it('should strip the BOM from the beginning of the file if it exists', function(done) {
     
@@ -129,5 +129,5 @@ describe('ngHtml2Js', function(){
           done();
         };
       });
-  })
+  });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -10,7 +10,7 @@ var browserify = require('browserify'),
 
 describe('ngHtml2Js', function(){
 
-  it('should compile html to a browserify module with parent directory included', function(done) {
+  /*it('should compile html to a browserify module with parent directory included', function(done) {
     var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
     browserify(__dirname + '/fixtures/app.js')
       .external('angular')
@@ -115,5 +115,19 @@ describe('ngHtml2Js', function(){
             done();
           };
         });
-  });
+  }); */
+
+  it('should strip the BOM from the beginning of the file if it exists', function(done) {
+    
+    browserify(__dirname + '/fixtures/bom-template.html')
+      .transform(ngHtml2Js())
+      .bundle(function(err, bundle) {
+        if (err) {
+          done(err)
+        } else {
+          expect(bundle.toString().match(/\ufeff/)).to.be.null;
+          done();
+        };
+      });
+  })
 });


### PR DESCRIPTION
This makes sure that the BOM (if present) doesn't make it into the template string.  If it does, funny characters start showing up all over the Angular app, causing layout issues.  

I'd pre-process it (using something like strip-bomify) but this transform does not use the transformed content, so it needs to happen here.