### PR TITLE
Add stripPathBefore option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,13 +21,16 @@ function ngHtml2jsify(opts) {
   opts = opts|| {};
   opts.module = opts.module || null;
   opts.extension = opts.extension || 'html';
-  opts.baseDir = opts.baseDir || null;
+  opts.baseDir = opts.baseDir || '';
   opts.prefix = opts.prefix || '';
   opts.requireAngular = opts.requireAngular || false;
+  opts.stripPathBefore = opts.stripPathBefore || null;
 
   var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
 
   return function (file) {
+    var stripStartIndex;
+
     if (!isExtension(file, opts.extension)) return through();
 
     var appDir = process.cwd();
@@ -35,7 +38,15 @@ function ngHtml2jsify(opts) {
     return transformify(end)();
 
     function end (content) {
-      var fileName = opts.baseDir ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
+      var fileName = opts.baseDir || opts.stripPathBefore ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
+
+      if (opts.stripPathBefore) {
+        stripStartIndex = fileName.indexOf(opts.stripPathBefore);
+
+        if (stripStartIndex !== -1) {
+          fileName = fileName.substr(stripStartIndex);
+        }
+      }
       fileName = opts.prefix + fileName;
       content = content.replace(/^\ufeff/g, '');
       var  src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';

--- a/test/fixtures/output-strippathbefore.js
+++ b/test/fixtures/output-strippathbefore.js
@@ -1,0 +1,14 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+var template = require('./template.html')
+
+},{"./template.html":2}],2:[function(require,module,exports){
+var ngModule = angular.module('fixtures/template.html', []);
+ngModule.run(['$templateCache', function($templateCache) {
+  $templateCache.put('fixtures/template.html',
+    '<h2>This is an html template</h2>\n' +
+    '<p>and it should be transformed into a browserify wrapped angular template module</p>\n' +
+    '');
+}]);
+
+module.exports = ngModule;
+},{}]},{},[1]);

--- a/test/spec.js
+++ b/test/spec.js
@@ -144,7 +144,7 @@ describe('ngHtml2Js', function(){
   });
 
   it('should strip the BOM from the beginning of the file if it exists', function(done) {
-    
+
     browserify(__dirname + '/fixtures/bom-template.html')
       .transform(ngHtml2Js())
       .bundle(function(err, bundle) {
@@ -155,5 +155,23 @@ describe('ngHtml2Js', function(){
           done();
         };
       });
+  });
+
+  it('should strip the path before the part provided if present', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-strippathbefore.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+    .external('angular')
+    .transform(ngHtml2Js({
+      stripPathBefore: 'fixtures/'
+    }))
+    .bundle(function (err, bundle) {
+      if (err) {
+        done(err)
+      } else {
+        expect(output).to.equal(bundle.toString());
+        done();
+      }
+      ;
+    });
   });
 });


### PR DESCRIPTION
This option allows the user to remove everything up to a certain point in the path when the module/file name are created. It comes in handy when you need more control over the paths.