### PR TITLE
exports filename instead of ngModule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Indentation override for all JS
+[**.js]
+indent_style = space
+indent_size = 2

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function ngHtml2jsify(opts) {
       }
       fileName = opts.prefix + fileName;
       content = content.replace(/^\ufeff/g, '');
-      var  src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
+      var  src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = "' + fileName + '";';
       if (opts.requireAngular) {
         src = 'var angular = require(\'angular\');\n' + src;
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,58 +4,58 @@ var fs = require('fs'),
     ngHtml2Js = require('ng-html2js'),
     transformify = require('transformify');
 
-function isExtension (file, extension) {
-  return new RegExp('\\.' + extension + '$').test(file);
+function isExtension(file, extension) {
+    return new RegExp('\\.' + extension + '$').test(file);
 }
 
 ngHtml2jsify.configure = function (filename, opts) {
-  if(typeof opts === 'undefined') { // gulp
-    return ngHtml2jsify(filename);
-  }else{ // CLI
-    return ngHtml2jsify(opts)(filename);
-  }
+    if (typeof opts === 'undefined') { // gulp
+        return ngHtml2jsify(filename);
+    } else { // CLI
+        return ngHtml2jsify(opts)(filename);
+    }
 
 };
 
 function ngHtml2jsify(opts) {
-  opts = opts|| {};
-  opts.module = opts.module || null;
-  opts.extension = opts.extension || 'html';
-  opts.baseDir = opts.baseDir || '';
-  opts.prefix = opts.prefix || '';
-  opts.requireAngular = opts.requireAngular || false;
-  opts.stripPathBefore = opts.stripPathBefore || null;
+    opts = opts || {};
+    opts.module = opts.module || null;
+    opts.extension = opts.extension || 'html';
+    opts.baseDir = opts.baseDir || '';
+    opts.prefix = opts.prefix || '';
+    opts.requireAngular = opts.requireAngular || false;
+    opts.stripPathBefore = opts.stripPathBefore || null;
 
-  var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
+    var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
 
-  return function (file) {
-    var stripStartIndex;
+    return function (file) {
+        var stripStartIndex;
 
-    if (!isExtension(file, opts.extension)) return through();
+        if (!isExtension(file, opts.extension)) return through();
 
-    var appDir = process.cwd();
+        var appDir = process.cwd();
 
-    return transformify(end)();
+        return transformify(end)();
 
-    function end (content) {
-      var fileName = opts.baseDir || opts.stripPathBefore ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
+        function end(content) {
+            var fileName = opts.baseDir || opts.stripPathBefore ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
 
-      if (opts.stripPathBefore) {
-        stripStartIndex = fileName.indexOf(opts.stripPathBefore);
+            if (opts.stripPathBefore) {
+                stripStartIndex = fileName.indexOf(opts.stripPathBefore);
 
-        if (stripStartIndex !== -1) {
-          fileName = fileName.substr(stripStartIndex);
+                if (stripStartIndex !== -1) {
+                    fileName = fileName.substr(stripStartIndex);
+                }
+            }
+            fileName = opts.prefix + fileName;
+            content = content.replace(/^\ufeff/g, '');
+            var src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = "' + fileName + '";';
+            if (opts.requireAngular) {
+                src = 'var angular = require(\'angular\');\n' + src;
+            }
+            return src;
         }
-      }
-      fileName = opts.prefix + fileName;
-      content = content.replace(/^\ufeff/g, '');
-      var  src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = "' + fileName + '";';
-      if (opts.requireAngular) {
-        src = 'var angular = require(\'angular\');\n' + src;
-      }
-      return src;
-    }
-  };
+    };
 }
 
 module.exports = ngHtml2jsify.configure;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,61 +1,61 @@
 var fs = require('fs'),
-    path = require('path'),
-    through = require('through'),
-    ngHtml2Js = require('ng-html2js'),
-    transformify = require('transformify');
+  path = require('path'),
+  through = require('through'),
+  ngHtml2Js = require('ng-html2js'),
+  transformify = require('transformify');
 
 function isExtension(file, extension) {
-    return new RegExp('\\.' + extension + '$').test(file);
+  return new RegExp('\\.' + extension + '$').test(file);
 }
 
 ngHtml2jsify.configure = function (filename, opts) {
-    if (typeof opts === 'undefined') { // gulp
-        return ngHtml2jsify(filename);
-    } else { // CLI
-        return ngHtml2jsify(opts)(filename);
-    }
+  if (typeof opts === 'undefined') { // gulp
+    return ngHtml2jsify(filename);
+  } else { // CLI
+    return ngHtml2jsify(opts)(filename);
+  }
 
 };
 
 function ngHtml2jsify(opts) {
-    opts = opts || {};
-    opts.module = opts.module || null;
-    opts.extension = opts.extension || 'html';
-    opts.baseDir = opts.baseDir || '';
-    opts.prefix = opts.prefix || '';
-    opts.requireAngular = opts.requireAngular || false;
-    opts.stripPathBefore = opts.stripPathBefore || null;
+  opts = opts || {};
+  opts.module = opts.module || null;
+  opts.extension = opts.extension || 'html';
+  opts.baseDir = opts.baseDir || '';
+  opts.prefix = opts.prefix || '';
+  opts.requireAngular = opts.requireAngular || false;
+  opts.stripPathBefore = opts.stripPathBefore || null;
 
-    var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
+  var fileMatching = new RegExp("^.*\\" + path.sep + "(.*)$");
 
-    return function (file) {
-        var stripStartIndex;
+  return function (file) {
+    var stripStartIndex;
 
-        if (!isExtension(file, opts.extension)) return through();
+    if (!isExtension(file, opts.extension)) return through();
 
-        var appDir = process.cwd();
+    var appDir = process.cwd();
 
-        return transformify(end)();
+    return transformify(end)();
 
-        function end(content) {
-            var fileName = opts.baseDir || opts.stripPathBefore ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
+    function end(content) {
+      var fileName = opts.baseDir || opts.stripPathBefore ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
 
-            if (opts.stripPathBefore) {
-                stripStartIndex = fileName.indexOf(opts.stripPathBefore);
+      if (opts.stripPathBefore) {
+        stripStartIndex = fileName.indexOf(opts.stripPathBefore);
 
-                if (stripStartIndex !== -1) {
-                    fileName = fileName.substr(stripStartIndex);
-                }
-            }
-            fileName = opts.prefix + fileName;
-            content = content.replace(/^\ufeff/g, '');
-            var src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = "' + fileName + '";';
-            if (opts.requireAngular) {
-                src = 'var angular = require(\'angular\');\n' + src;
-            }
-            return src;
+        if (stripStartIndex !== -1) {
+          fileName = fileName.substr(stripStartIndex);
         }
-    };
+      }
+      fileName = opts.prefix + fileName;
+      content = content.replace(/^\ufeff/g, '');
+      var src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = "' + fileName + '";';
+      if (opts.requireAngular) {
+        src = 'var angular = require(\'angular\');\n' + src;
+      }
+      return src;
+    }
+  };
 }
 
 module.exports = ngHtml2jsify.configure;

--- a/test/fixtures/output-basedir.js
+++ b/test/fixtures/output-basedir.js
@@ -10,5 +10,5 @@ ngModule.run(['$templateCache', function($templateCache) {
     '');
 }]);
 
-module.exports = ngModule;
+module.exports = "/fixtures/template.html";
 },{}]},{},[1]);

--- a/test/fixtures/output-prefix.js
+++ b/test/fixtures/output-prefix.js
@@ -10,5 +10,5 @@ ngModule.run(['$templateCache', function($templateCache) {
     '');
 }]);
 
-module.exports = ngModule;
+module.exports = "/app.templates/template.html";
 },{}]},{},[1]);

--- a/test/fixtures/output-require-angular.js
+++ b/test/fixtures/output-require-angular.js
@@ -11,5 +11,5 @@ ngModule.run(['$templateCache', function($templateCache) {
     '');
 }]);
 
-module.exports = ngModule;
+module.exports = "template.html";
 },{"angular":"angular"}]},{},[1]);

--- a/test/fixtures/output-simple.js
+++ b/test/fixtures/output-simple.js
@@ -10,5 +10,5 @@ ngModule.run(['$templateCache', function($templateCache) {
     '');
 }]);
 
-module.exports = ngModule;
+module.exports = "template.html";
 },{}]},{},[1]);

--- a/test/fixtures/output-strippathbefore.js
+++ b/test/fixtures/output-strippathbefore.js
@@ -10,5 +10,5 @@ ngModule.run(['$templateCache', function($templateCache) {
     '');
 }]);
 
-module.exports = ngModule;
+module.exports = "fixtures/template.html";
 },{}]},{},[1]);

--- a/test/fixtures/output-uppercase.js
+++ b/test/fixtures/output-uppercase.js
@@ -16,5 +16,5 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '');
 }]);
 
-module.exports = ngModule;
+module.exports = "template.html";
 },{}]},{},[1]);

--- a/test/fixtures/output.js
+++ b/test/fixtures/output.js
@@ -16,5 +16,5 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '');
 }]);
 
-module.exports = ngModule;
+module.exports = "template.html";
 },{}]},{},[1]);

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,182 +1,182 @@
 var browserify = require('browserify'),
-    fs = require('fs'),
-    ngHtml2Js = require('../lib'),
-    source = require('vinyl-source-stream'),
-    transformify = require('transformify'),
-    expect = require('chai').expect,
-    cwd = process.cwd(),
-    path = require('path'),
-    exec = require('child_process').exec;
+  fs = require('fs'),
+  ngHtml2Js = require('../lib'),
+  source = require('vinyl-source-stream'),
+  transformify = require('transformify'),
+  expect = require('chai').expect,
+  cwd = process.cwd(),
+  path = require('path'),
+  exec = require('child_process').exec;
 
 
 describe('ngHtml2Js', function () {
 
-    it('should compile html to a browserify module with parent directory included', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(ngHtml2Js({
-                baseDir: '/test'
-            }))
-            .bundle(function (err, bundle) {
+  it('should compile html to a browserify module with parent directory included', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(ngHtml2Js({
+        baseDir: '/test'
+      }))
+      .bundle(function (err, bundle) {
 
-                if (err) {
-                    done(err);
-                } else {
-                    expect(output).to.equal(bundle.toString());
-                    done();
-                }
-            });
+        if (err) {
+          done(err);
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        }
+      });
+  });
+
+  it('should put path in unix-like format even for windows-users', function (done) {
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(ngHtml2Js({
+        baseDir: '/test'
+      }))
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(/\/fixtures\/template\.html/.test(bundle.toString())).to.be.true();
+          done();
+        }
+      });
+  });
+
+
+  it('should compile html to a browserify wrapped angular module', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(ngHtml2Js({
+        module: 'templates'
+      }))
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        }
+      });
+  });
+
+  it('should honor earlier transforms', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-uppercase.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(function (file) {
+        return transformify(function (s) {
+          if (/\.html?/.test(file)) {
+            return s.toUpperCase();
+          }
+          return s;
+        })();
+      })
+      .transform(ngHtml2Js({
+        module: 'templates'
+      }))
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        }
+      });
+  });
+
+  it('should compile html to a browserify wrapped angular module in CLI', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
+    exec('browserify -t [./lib/index.js --module templates] --external angular ./test/fixtures/app.js', function (error, stdout, stderr) {
+      expect(output).to.equal(stdout);
+      done();
     });
+  });
 
-    it('should put path in unix-like format even for windows-users', function (done) {
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(ngHtml2Js({
-                baseDir: '/test'
-            }))
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(/\/fixtures\/template\.html/.test(bundle.toString())).to.be.true();
-                    done();
-                }
-            });
-    });
+  it('should compile html to a browserify wrapped angular module without a module', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-simple.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(ngHtml2Js())
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        }
 
+      });
+  });
 
-    it('should compile html to a browserify wrapped angular module', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(ngHtml2Js({
-                module: 'templates'
-            }))
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(output).to.equal(bundle.toString());
-                    done();
-                }
-            });
-    });
+  it('should add prefix to filename if one is provided', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-prefix.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(ngHtml2Js({
+        prefix: '/app.templates/'
+      }))
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        }
+      });
+  });
 
-    it('should honor earlier transforms', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output-uppercase.js', 'utf-8');
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(function (file) {
-                return transformify(function (s) {
-                    if (/\.html?/.test(file)) {
-                        return s.toUpperCase();
-                    }
-                    return s;
-                })();
-            })
-            .transform(ngHtml2Js({
-                module: 'templates'
-            }))
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(output).to.equal(bundle.toString());
-                    done();
-                }
-            });
-    });
+  it('should include a require angular statement inside module', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-require-angular.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(ngHtml2Js({
+        requireAngular: true
+      }))
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        }
 
-    it('should compile html to a browserify wrapped angular module in CLI', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
-        exec('browserify -t [./lib/index.js --module templates] --external angular ./test/fixtures/app.js', function (error, stdout, stderr) {
-            expect(output).to.equal(stdout);
-            done();
-        });
-    });
+      });
+  });
 
-    it('should compile html to a browserify wrapped angular module without a module', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output-simple.js', 'utf-8');
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(ngHtml2Js())
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(output).to.equal(bundle.toString());
-                    done();
-                }
+  it('should strip the BOM from the beginning of the file if it exists', function (done) {
 
-            });
-    });
+    browserify(__dirname + '/fixtures/bom-template.html')
+      .transform(ngHtml2Js())
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(bundle.toString().match(/\ufeff/)).to.be.null;
+          done();
+        }
 
-    it('should add prefix to filename if one is provided', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output-prefix.js', 'utf-8');
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(ngHtml2Js({
-                prefix: '/app.templates/'
-            }))
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(output).to.equal(bundle.toString());
-                    done();
-                }
-            });
-    });
+      });
+  });
 
-    it('should include a require angular statement inside module', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output-require-angular.js', 'utf-8');
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(ngHtml2Js({
-                requireAngular: true
-            }))
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(output).to.equal(bundle.toString());
-                    done();
-                }
+  it('should strip the path before the part provided if present', function (done) {
+    var output = fs.readFileSync(__dirname + '/fixtures/output-strippathbefore.js', 'utf-8');
+    browserify(__dirname + '/fixtures/app.js')
+      .external('angular')
+      .transform(ngHtml2Js({
+        stripPathBefore: 'fixtures/'
+      }))
+      .bundle(function (err, bundle) {
+        if (err) {
+          done(err);
+        } else {
+          expect(output).to.equal(bundle.toString());
+          done();
+        }
 
-            });
-    });
-
-    it('should strip the BOM from the beginning of the file if it exists', function (done) {
-
-        browserify(__dirname + '/fixtures/bom-template.html')
-            .transform(ngHtml2Js())
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(bundle.toString().match(/\ufeff/)).to.be.null;
-                    done();
-                }
-
-            });
-    });
-
-    it('should strip the path before the part provided if present', function (done) {
-        var output = fs.readFileSync(__dirname + '/fixtures/output-strippathbefore.js', 'utf-8');
-        browserify(__dirname + '/fixtures/app.js')
-            .external('angular')
-            .transform(ngHtml2Js({
-                stripPathBefore: 'fixtures/'
-            }))
-            .bundle(function (err, bundle) {
-                if (err) {
-                    done(err);
-                } else {
-                    expect(output).to.equal(bundle.toString());
-                    done();
-                }
-
-            });
-    });
+      });
+  });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -9,169 +9,174 @@ var browserify = require('browserify'),
     exec = require('child_process').exec;
 
 
-describe('ngHtml2Js', function(){
+describe('ngHtml2Js', function () {
 
-  it('should compile html to a browserify module with parent directory included', function(done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
-    browserify(__dirname + '/fixtures/app.js')
-      .external('angular')
-      .transform(ngHtml2Js({
-        baseDir: '/test'
-      }))
-      .bundle(function(err, bundle) {
-        if (err) {
-          done(err)
-        } else {
-          expect(output).to.equal(bundle.toString());
-          done();
-        };
-      });
-  });
+    it('should compile html to a browserify module with parent directory included', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output-basedir.js', 'utf-8');
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(ngHtml2Js({
+                baseDir: '/test'
+            }))
+            .bundle(function (err, bundle) {
 
-  it('should put path in unix-like format even for windows-users', function(done) {
-    browserify(__dirname + '/fixtures/app.js')
-      .external('angular')
-      .transform(ngHtml2Js({
-        baseDir: '/test'
-      }))
-      .bundle(function(err, bundle) {
-        if (err) {
-          done(err)
-        } else {
-          expect(/\/fixtures\/template\.html/.test(bundle.toString())).to.be.true();
-          done();
-        };
-      });
-  });
-
-  it('should compile html to a browserify wrapped angular module', function(done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
-    browserify(__dirname + '/fixtures/app.js')
-      .external('angular')
-      .transform(ngHtml2Js({
-        module: 'templates'
-      }))
-      .bundle(function(err, bundle) {
-        if (err) {
-          done(err)
-        } else {
-          expect(output).to.equal(bundle.toString());
-          done();
-        };
-      });
-  });
-
-  it('should honor earlier transforms', function(done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output-uppercase.js', 'utf-8');
-    browserify(__dirname + '/fixtures/app.js')
-      .external('angular')
-      .transform(function(file){
-        return transformify(function(s) {
-          if(/\.html?/.test(file)) {
-            return s.toUpperCase();
-          }
-          return s;
-        })();
-      })
-      .transform(ngHtml2Js({
-        module: 'templates'
-      }))
-      .bundle(function(err, bundle) {
-        if (err) {
-          done(err)
-        } else {
-          expect(output).to.equal(bundle.toString());
-          done();
-        }
-      });
-  });
-
-  it('should compile html to a browserify wrapped angular module in CLI', function(done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
-    exec('browserify -t [./lib/index.js --module templates] --external angular ./test/fixtures/app.js', function (error, stdout, stderr) {
-      expect(output).to.equal(stdout);
-      done();
+                if (err) {
+                    done(err);
+                } else {
+                    expect(output).to.equal(bundle.toString());
+                    done();
+                }
+            });
     });
-  });
 
-  it('should compile html to a browserify wrapped angular module without a module', function(done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output-simple.js', 'utf-8');
-    browserify(__dirname + '/fixtures/app.js')
-      .external('angular')
-      .transform(ngHtml2Js())
-      .bundle(function(err, bundle) {
-        if (err) {
-          done(err)
-        } else {
-          expect(output).to.equal(bundle.toString());
-          done();
-        };
-      });
-  });
+    it('should put path in unix-like format even for windows-users', function (done) {
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(ngHtml2Js({
+                baseDir: '/test'
+            }))
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(/\/fixtures\/template\.html/.test(bundle.toString())).to.be.true();
+                    done();
+                }
+            });
+    });
 
-  it('should add prefix to filename if one is provided', function(done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output-prefix.js', 'utf-8');
-    browserify(__dirname + '/fixtures/app.js')
-      .external('angular')
-      .transform(ngHtml2Js({
-        prefix: '/app.templates/'
-      }))
-      .bundle(function(err, bundle) {
-        if (err) {
-          done(err)
-        } else {
-          expect(output).to.equal(bundle.toString());
-          done();
-        };
-      });
-  });
 
-  it('should include a require angular statement inside module', function(done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output-require-angular.js', 'utf-8');
-    browserify(__dirname + '/fixtures/app.js')
-        .external('angular')
-        .transform(ngHtml2Js({
-          requireAngular: true
-        }))
-        .bundle(function(err, bundle) {
-          if (err) {
-            done(err)
-          } else {
-            expect(output).to.equal(bundle.toString());
+    it('should compile html to a browserify wrapped angular module', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(ngHtml2Js({
+                module: 'templates'
+            }))
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(output).to.equal(bundle.toString());
+                    done();
+                }
+            });
+    });
+
+    it('should honor earlier transforms', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output-uppercase.js', 'utf-8');
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(function (file) {
+                return transformify(function (s) {
+                    if (/\.html?/.test(file)) {
+                        return s.toUpperCase();
+                    }
+                    return s;
+                })();
+            })
+            .transform(ngHtml2Js({
+                module: 'templates'
+            }))
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(output).to.equal(bundle.toString());
+                    done();
+                }
+            });
+    });
+
+    it('should compile html to a browserify wrapped angular module in CLI', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output.js', 'utf-8');
+        exec('browserify -t [./lib/index.js --module templates] --external angular ./test/fixtures/app.js', function (error, stdout, stderr) {
+            expect(output).to.equal(stdout);
             done();
-          };
         });
-  });
-
-  it('should strip the BOM from the beginning of the file if it exists', function(done) {
-
-    browserify(__dirname + '/fixtures/bom-template.html')
-      .transform(ngHtml2Js())
-      .bundle(function(err, bundle) {
-        if (err) {
-          done(err)
-        } else {
-          expect(bundle.toString().match(/\ufeff/)).to.be.null;
-          done();
-        };
-      });
-  });
-
-  it('should strip the path before the part provided if present', function (done) {
-    var output = fs.readFileSync(__dirname + '/fixtures/output-strippathbefore.js', 'utf-8');
-    browserify(__dirname + '/fixtures/app.js')
-    .external('angular')
-    .transform(ngHtml2Js({
-      stripPathBefore: 'fixtures/'
-    }))
-    .bundle(function (err, bundle) {
-      if (err) {
-        done(err)
-      } else {
-        expect(output).to.equal(bundle.toString());
-        done();
-      }
-      ;
     });
-  });
+
+    it('should compile html to a browserify wrapped angular module without a module', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output-simple.js', 'utf-8');
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(ngHtml2Js())
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(output).to.equal(bundle.toString());
+                    done();
+                }
+
+            });
+    });
+
+    it('should add prefix to filename if one is provided', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output-prefix.js', 'utf-8');
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(ngHtml2Js({
+                prefix: '/app.templates/'
+            }))
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(output).to.equal(bundle.toString());
+                    done();
+                }
+            });
+    });
+
+    it('should include a require angular statement inside module', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output-require-angular.js', 'utf-8');
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(ngHtml2Js({
+                requireAngular: true
+            }))
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(output).to.equal(bundle.toString());
+                    done();
+                }
+
+            });
+    });
+
+    it('should strip the BOM from the beginning of the file if it exists', function (done) {
+
+        browserify(__dirname + '/fixtures/bom-template.html')
+            .transform(ngHtml2Js())
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(bundle.toString().match(/\ufeff/)).to.be.null;
+                    done();
+                }
+
+            });
+    });
+
+    it('should strip the path before the part provided if present', function (done) {
+        var output = fs.readFileSync(__dirname + '/fixtures/output-strippathbefore.js', 'utf-8');
+        browserify(__dirname + '/fixtures/app.js')
+            .external('angular')
+            .transform(ngHtml2Js({
+                stripPathBefore: 'fixtures/'
+            }))
+            .bundle(function (err, bundle) {
+                if (err) {
+                    done(err);
+                } else {
+                    expect(output).to.equal(bundle.toString());
+                    done();
+                }
+
+            });
+    });
 });


### PR DESCRIPTION
With this change you don't have to know the full generated filename of the directive.html.
Just add something like `var template = require('./template.html');` and you can use the template var to reference angular to the correct template.